### PR TITLE
ci: rename workflow file for auto tagging and release

### DIFF
--- a/.github/workflows/release_and_tagging.yml
+++ b/.github/workflows/release_and_tagging.yml
@@ -91,22 +91,6 @@ jobs:
       #          draft: false
       #          prerelease: false
 
-      - name: Generate changelog
-        id: generate_changelog
-        run: |
-          LATEST_RELEASE=${{ steps.get_latest_release.outputs.LATEST_RELEASE }}
-          echo "# Changelog" > changelog.txt
-          if [[ -z "$LATEST_RELEASE" ]]; then
-            # If there's no previous release, get only the current commit's log
-            git config --global core.pager cat
-            # git log --pretty=format:"* %s **by** @%an"
-            git log --pretty=format:"* %s **by** @%an" >> changelog.txt
-          else
-            # Get all submission information since the last release
-            CHANGELOG=$(git log "$LATEST_RELEASE"..HEAD --pretty=format:"* %s **by** @%an")
-            git log "$LATEST_RELEASE"..HEAD --pretty=format:"* %s **by** @%an" >> changelog.txt
-          fi
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         if: success() && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
- Renamed `.github/workflows/tag_after_test.yml` to `.github/workflows/release_and_tagging.yml`
- Updated workflow file to include GoReleaser step for building and publishing releases
- Improved clarity and organization of the workflow steps

