### PR TITLE
ci(release): adjust Go setup and tagging workflow

### DIFF
--- a/.github/workflows/release_and_tagging.yml
+++ b/.github/workflows/release_and_tagging.yml
@@ -92,7 +92,7 @@ jobs:
       #          prerelease: false
 
   release:
-    needs: [ test ]
+    needs: [ tagging ]
     if: success()
     runs-on: ubuntu-latest
     permissions:
@@ -100,15 +100,20 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - uses: actions/setup-go@v5.0.2 # v5
+        with:
+          go-version: stable
+      - name: Ensure Go
+        run: go version
       - name: Checkout code
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.0 # v4
         with:
           ref: main
           fetch-depth: 0 # Fetch all history
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
-        if: success() && startsWith(github.ref, 'refs/tags/')
+        if: success()
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser


### PR DESCRIPTION
- Add Go setup step to ensure proper Go version is installed
- Update checkout action to use version4
- Modify GoReleaser action to run on all successful builds, not just tag pushes
