### PR TITLE
build(release): update Goreleaser configuration for Go-Gins

### DIFF
--- a/.github/workflows/release_and_tagging.yml
+++ b/.github/workflows/release_and_tagging.yml
@@ -118,8 +118,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean
-          workdir: cmd/protoc-gen-go-gins
+          args: release --clean -f ./cmd/protoc-gen-go-gins/.goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Modify the release step in the GitHub Actions workflow
- Use the `-f` flag to specify the exact location of the .goreleaser.yaml file
- Remove the `workdir` setting as it's no longer necessary

