### PR TITLE
ci(release): update GitHub release name to reflect project structure

### DIFF
--- a/cmd/protoc-gen-go-gins/.goreleaser.yaml
+++ b/cmd/protoc-gen-go-gins/.goreleaser.yaml
@@ -105,7 +105,7 @@ changelog:
 release:
   github:
     owner: OrigAdmin
-    name: protoc-gen-go-gins
+    name: toolkits/cmd/protoc-gen-go-gins
   prerelease: auto
   draft: false
   make_latest: true


### PR DESCRIPTION
Change the GitHub release name from 'protoc-gen-go-gins' to 'toolkits/cmd/protoc-gen-go-gins' to better represent the project's directory structure and improve organization for the upcoming toolkit release.
