### PR TITLE
ci(goreleaser): update release name to toolkits

### DIFF
--- a/cmd/protoc-gen-go-gins/.goreleaser.yaml
+++ b/cmd/protoc-gen-go-gins/.goreleaser.yaml
@@ -105,7 +105,7 @@ changelog:
 release:
   github:
     owner: OrigAdmin
-    name: toolkits/cmd/protoc-gen-go-gins
+    name: toolkits
   prerelease: auto
   draft: false
   make_latest: true


### PR DESCRIPTION
Changed the release name from 'toolkits/cmd/protoc-gen-go-gins' to 'toolkits' in the .goreleaser.yaml file. This modification simplifies the release name, making it more concise and aligned with the project's structure.
