### PR TITLE
refactor(security): correct naming inconsistency in security contexts

### DIFF
--- a/security/security.go
+++ b/security/security.go
@@ -14,8 +14,8 @@ const (
 	ContextTypeContext TokenType = iota
 	// ContextTypeHeader represents the context type for the header.
 	ContextTypeHeader
-	// ContentTypeMetadata represents the context type for the metadata.
-	ContentTypeMetadata
+	// ContextTypeMetadata represents the context type for the metadata.
+	ContextTypeMetadata
 	// ContextTypeQuery represents the context type for the query.
 	ContextTypeQuery
 	// ContextTypeCookie represents the context type for the cookie.


### PR DESCRIPTION
- Rename ContentTypeMetadata to ContextTypeMetadata for consistency with other context types


