### PR TITLE
chore(ci): prevent dependabot from triggering release and testing wor…

### DIFF
--- a/.github/workflows/release_and_tagging.yml
+++ b/.github/workflows/release_and_tagging.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   tagging:
-    if: github.actor != 'dependabot[bot]' && github.repository == 'owner/repo'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/testing_on_push.yml
+++ b/.github/workflows/testing_on_push.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    if: github.actor != 'dependabot[bot]' && github.repository == 'owner/repo'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Log information about the push


### PR DESCRIPTION
- Update release_and_tagging.yml to ignore dependabot pushes
- Update testing_on_push.yml to ignore dependabot pushes
- Add conditional checks to ensure dependabot doesn't trigger these workflows

