### PR TITLE
refactor(security): move token destruction methods to AuthN

### DIFF
--- a/security/authn.go
+++ b/security/authn.go
@@ -16,4 +16,8 @@ type Authenticator interface {
 	// AuthenticateContext returns a nil error and the AuthClaims info (if available).
 	// if the subject is authenticated or a non-nil error with an appropriate error cause otherwise.
 	AuthenticateContext(context.Context, TokenType) (Claims, error)
+	// DestroyToken invalidate a token by removing it from the token store.
+	DestroyToken(context.Context, string) error
+	// DestroyRefreshToken by removing from the token store to invalidate a refresh token
+	DestroyRefreshToken(context.Context, string) error
 }

--- a/security/tokenizer.go
+++ b/security/tokenizer.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Tokenizer interface {
-	// CreateClaims creates a new identity claims. bool true is for refresh token
+	// CreateClaims creates a new identity claims.
 	CreateClaims(context.Context, string) (Claims, error)
 	// CreateToken inject user claims into token string.
 	CreateToken(context.Context, Claims) (string, error)
@@ -18,18 +18,10 @@ type Tokenizer interface {
 	ParseClaims(context.Context, string) (Claims, error)
 	// Validate validates if a token is valid.
 	Validate(context.Context, string) (bool, error)
-	// DestroyToken invalidate a token by removing it from the token store.
-	DestroyToken(context.Context, string) error
 }
 
 type RefreshTokenizer interface {
 	Tokenizer
 	// CreateRefreshClaims creates a new identity claims specifically for a refresh token.
 	CreateRefreshClaims(context.Context, string) (Claims, error)
-	// CreateRefreshToken create a new Refresh token.
-	CreateRefreshToken(context.Context, Claims) (string, error)
-	// ValidateRefreshToken validate refresh token is valid
-	ValidateRefreshToken(context.Context, string) (bool, error)
-	// DestroyRefreshToken by removing from the token store to invalidate a refresh token
-	DestroyRefreshToken(context.Context, string) error
 }


### PR DESCRIPTION
- Remove DestroyToken and DestroyRefreshToken methods from Tokenizer and RefreshTokenizer interfaces
- Add these methods to the AuthN interface instead
- This change simplifies the Tokenizer interfaces and centralizes token destruction logic in AuthN

